### PR TITLE
Pin dependencies on hash instead of versions

### DIFF
--- a/.github/workflows/swarm.yml
+++ b/.github/workflows/swarm.yml
@@ -10,6 +10,9 @@ on:
       - 'broker/mosquitto.conf'
       - '.github/workflows/swarm.yml'
 
+permissions:
+  actions: read
+
 jobs:
   tests:
     uses: FirstForce/SS/.github/workflows/tests.yml@4f94105d0f482895fc049a024708e2d7cade1baf

--- a/.github/workflows/swarm.yml
+++ b/.github/workflows/swarm.yml
@@ -12,7 +12,7 @@ on:
 
 jobs:
   tests:
-    uses: FirstForce/SS/.github/workflows/tests.yml@main
+    uses: FirstForce/SS/.github/workflows/tests.yml@4f94105d0f482895fc049a024708e2d7cade1baf
 
   deploy:
     needs: tests
@@ -23,13 +23,13 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v3
+      uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744
 
     - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v3
+      uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2
 
     - name: Log in to Docker Hub
-      uses: docker/login-action@v3
+      uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772
       with:
         username: ${{ secrets.DOCKER_USERNAME }}
         password: ${{ secrets.DOCKER_PASSWORD }}
@@ -48,7 +48,7 @@ jobs:
         sed "s|$IMAGE_NAME:.*|$IMAGE_NAME:${{ steps.vars.outputs.sha_short }}|" docker-compose.yml > docker-compose.deploy.yml
 
     - name: Copy Compose file to remote server
-      uses: appleboy/scp-action@v0.1.3
+      uses: appleboy/scp-action@6d1fc191a822daa12faa45f3a985413f995ff5c5
       with:
         host: ${{ secrets.SSH_HOST }}
         username: ${{ secrets.SSH_USER }}
@@ -57,7 +57,7 @@ jobs:
         target: "/home/${{ secrets.SSH_USER }}/mystack/"
 
     - name: Copy Mosquitto Config file to remote server
-      uses: appleboy/scp-action@v0.1.3
+      uses: appleboy/scp-action@6d1fc191a822daa12faa45f3a985413f995ff5c5
       with:
         host: ${{ secrets.SSH_HOST }}
         username: ${{ secrets.SSH_USER }}
@@ -66,7 +66,7 @@ jobs:
         target: "/home/${{ secrets.SSH_USER }}/mystack/"
 
     - name: Deploy updated stack on remote server
-      uses: appleboy/ssh-action@v1.0.0
+      uses: appleboy/ssh-action@55dabf81b49d4120609345970c91507e2d734799
       with:
         host: ${{ secrets.SSH_HOST }}
         username: ${{ secrets.SSH_USER }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -7,6 +7,9 @@ on:
       - '.github/workflows/tests.yml'
   workflow_call:
 
+permissions:
+  actions: read
+
 jobs:
   test-routes:
     name: Run tests for ./server/routes

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,10 +14,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744
 
       - name: Set up Go
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@19bb51245e9c80abacb2e91cc42b33fa478b8639
         with:
           go-version: '1.24' # Update as needed
 

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:alpine AS build-env
+FROM golang:alpine@sha256:ef18ee7117463ac1055f5a370ed18b8750f01589f13ea0b48642f5792b234044 AS build-env
 
 WORKDIR /app
 COPY . /app
@@ -15,7 +15,7 @@ RUN apk add --no-cache \
 
 # test
 RUN CGO_ENABLED=1 GOOS=linux GOARCH=amd64 go build -o mqtt ./main.go
-FROM alpine
+FROM alpine@sha256:a8560b36e8b8210634f77d9f7f9efd7ffa463e380b75e2e74aff4511df3ef88c
 WORKDIR /app
 COPY --from=build-env /app/mqtt /app/
 


### PR DESCRIPTION
Pin github actions and dockerfile dependencies on hash values (commit or image digest) instead of versions.