### PR TITLE
Potential fix for code scanning alert no. 1: Disabled TLS certificate check

### DIFF
--- a/server/main.go
+++ b/server/main.go
@@ -49,7 +49,7 @@ func NewTLSConfig() *tls.Config {
 		ClientCAs: certpool,
 		// InsecureSkipVerify = verify that cert contents
 		// match server. IP matches what is in cert etc.
-		InsecureSkipVerify: true,
+		InsecureSkipVerify: false,
 		// Certificates = list of certs client sends to server.
 		Certificates: []tls.Certificate{cert},
 	}


### PR DESCRIPTION
Potential fix for [https://github.com/FirstForce/SS/security/code-scanning/1](https://github.com/FirstForce/SS/security/code-scanning/1)

To fix the issue, the `InsecureSkipVerify` field should be set to `false` to enable proper TLS certificate verification. This ensures that the server's certificate chain and hostname are validated, protecting against MITM attacks. The existing code already loads trusted CA certificates and a client certificate, so no additional changes are required to support secure TLS communication. The fix involves modifying the `NewTLSConfig` function to set `InsecureSkipVerify: false`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
